### PR TITLE
Clarify misleading text in PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -1,7 +1,7 @@
 ### Requirements for Adding, Changing, or Removing a Feature
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/EqualExperts/ee-slack-gardener/blob/master/.github/PULL_REQUEST_TEMPLATE
+* The pull request must only change an existing feature or introduce new functionality. To contribute other changes, you must use a different template. You can see all templates at https://github.com/EqualExperts/ee-slack-gardener/blob/master/.github/PULL_REQUEST_TEMPLATE
 * The pull request must update the test suite to demonstrate the changed functionality.
 
 ### Description of the Change

--- a/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -1,7 +1,7 @@
 ### Requirements for Contributing a Performance Improvement
 
 * Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/EqualExperts/ee-slack-gardener/blob/master/.github/PULL_REQUEST_TEMPLATE
+* The pull request must only be related to performance improvement. To contribute other changes, you must use a different template. You can see all templates at https://github.com/EqualExperts/ee-slack-gardener/blob/master/.github/PULL_REQUEST_TEMPLATE
 * The pull request must update the test suite to demonstrate the changed functionality.
 
 ### Description of the Change


### PR DESCRIPTION
### Description of the Change

* The `feature_change` and `performance_improvement` PR templates contained references to bug fixes which was somewhat misleading. This is an attempt at a clarification.

### Release Notes

Clarify text in `feature_change` and `performance_improvment` PR templates