### PR TITLE
Improve gradle: calculate jar hash using pure java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 import com.amazonaws.services.s3.model.ObjectMetadata
 import jp.classmethod.aws.gradle.s3.AmazonS3FileUploadTask
 
+import java.security.DigestOutputStream
+import java.security.MessageDigest
+
 buildscript {
     ext {
         kotlinVersion = '1.3.+'
@@ -97,11 +100,18 @@ aws {
 }
 
 task buildHashFile() {
+    dependsOn(jar)
     def result = file("build/ee-slack-gardener-lambda.base64sha256")
     outputs.file result
     doLast {
-        println "./scripts/generate_lambda_file_hash.sh".execute().text.trim()
-        result.write("./scripts/generate_lambda_file_hash.sh".execute().text.trim(), 'UTF-8')
+        def input = jar.archiveFile.get().getAsFile().newInputStream()
+        def digest = MessageDigest.getInstance("SHA-256")
+        new DigestOutputStream(new NullOutputStream(), digest) << input
+        input.close()
+        def hash = digest.digest().encodeBase64().toString()
+        
+        println(hash)
+        result.text = hash
     }
 }
 
@@ -124,4 +134,9 @@ task uploadLambda(type: AmazonS3FileUploadTask, dependsOn: build) {
 task upload() {
     dependsOn uploadLambda
     dependsOn uploadLambdaHash
+}
+
+class NullOutputStream extends OutputStream {
+    @Override
+    void write(int b) {}
 }

--- a/scripts/generate_lambda_file_hash.sh
+++ b/scripts/generate_lambda_file_hash.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-openssl dgst -sha256 -binary build/libs/ee-slack-gardener-0.0.1-SNAPSHOT.jar | openssl enc -base64


### PR DESCRIPTION
### Description of the Change

Some gradle cleanup. Uses pure java (well, pure groovy) to calculate the file hash instead of calling out to a shell script.

This change also:
* avoids hardcoding the jar file name in the shell script
* only calculates the hash once instead of twice
* depends on the jar task so you can't try and calculate the hash when the jar doesn't exist

### Alternate Designs
You could use a plugin instead of doing this in the build.gradle file

### Possible Drawbacks
None that I know of

### Verification Process
Check to see that file hashes are still calculated. This PR doesn't change the contents of the jar at all, so you should be able to run `gradle build`, run `gradle buildHashFile`, apply the PR, run `gradle buildHashFile` again, and get the same result

### Release Notes
Same as the description I guess?